### PR TITLE
add installer crd to local dev target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,13 +281,11 @@ build: prebuild-check deps check-go-format
 # deploy
 # -------------------------------------------------------------------
 
-# to watch all namespaces, keep namespace empty
-APP_NAMESPACE ?= ""
 LOCAL_TEST_NAMESPACE ?= "local-test"
 .PHONY: local
 ## Run Operator locally
 local: deploy-rbac build deploy-crd
-	operator-sdk up local --namespace=$(APP_NAMESPACE)
+	operator-sdk up local --namespace=$(LOCAL_TEST_NAMESPACE)
 
 .PHONY: deploy-rbac
 ## Setup service account and deploy RBAC
@@ -302,6 +300,7 @@ deploy-rbac:
 deploy-crd:
 	@-oc apply -f deploy/crds/devopsconsole_v1alpha1_component_crd.yaml
 	@-oc apply -f deploy/crds/devopsconsole_v1alpha1_gitsource_crd.yaml
+	@-oc apply -f deploy/crds/devopsconsole_v1alpha1_installer_crd.yaml
 
 .PHONY: deploy-operator
 ## Deploy Operator


### PR DESCRIPTION
Add deployment of installer CRD to avoid error:
```
{"level":"error","ts":1553777239.09963,"logger":"cmd","caller":"manager/main.go:120","msg":"","error":"no matches for kind \"Installer\" in version \"devopsconsole.openshift.io/v1alpha1\"","stacktrace":"github.com/redhat-developer/devopsconsole-operator/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/corinne/workspace/go/src/github.com/redhat-developer/devopsconsole-operator/vendor/github.com/go-logr/zapr/zapr.go:128\nmain.main\n\t/Users/corinne/workspace/go/src/github.com/redhat-developer/devopsconsole-operator/cmd/manager/main.go:120\nruntime.main\n\t/Users/corinne/.gvm/gos/go1.11.2/src/runtime/proc.go:201"}
Error: failed to run operator locally: (failed to exec []string{"build/_output/bin/devopsconsole-operator-local"}: exit status 1)
```
when starting `make local`